### PR TITLE
Fix/charging station waiting forever in send request after stopped

### DIFF
--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -481,11 +481,15 @@ func (cs *chargingStation) SendRequest(request ocpp.Request) (ocpp.Response, err
 	if err != nil {
 		return nil, err
 	}
-	asyncResult, ok := <-asyncResponseC
-	if !ok {
-		return nil, fmt.Errorf("internal error while receiving result for %v request", request.GetFeatureName())
+	select {
+	case asyncResult, ok := <-asyncResponseC:
+		if !ok {
+			return nil, fmt.Errorf("internal error while receiving result for %v request", request.GetFeatureName())
+		}
+		return asyncResult.r, asyncResult.e
+	case <-cs.stopC:
+		return nil, fmt.Errorf("client stopped while waiting for response to %v", request.GetFeatureName())
 	}
-	return asyncResult.r, asyncResult.e
 }
 
 func (cs *chargingStation) SendRequestAsync(request ocpp.Request, callback func(response ocpp.Response, err error)) error {

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -588,7 +588,13 @@ func (cs *chargingStation) Start(csmsUrl string) error {
 }
 
 func (cs *chargingStation) Stop() {
+	close(cs.stopC)
 	cs.client.Stop()
+
+	if cs.errC != nil {
+		close(cs.errC)
+		cs.errC = nil
+	}
 }
 
 func (cs *chargingStation) notImplementedError(requestId string, action string) {


### PR DESCRIPTION
We had the same issue with the OCPP 1.6 charging_point.go which was fixed by Mike and also put upstream.
See https://github.com/grid-x/ocpp-go/blob/c020c2b1039ad5191ac3b23c049b7e50efbff648/ocpp1.6/charge_point.go#L209 and https://github.com/grid-x/ocpp-go/blob/c020c2b1039ad5191ac3b23c049b7e50efbff648/ocpp1.6/charge_point.go#L335

We actually need this for our clients OCPP 2.0.1 unit tests to succeed. Otherwise, there will be a goroutine not finishing which lets `goleak.VerifyNone(t)` fail.