### PR TITLE
fix/improve_clients_stop_function

### DIFF
--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -101,15 +101,8 @@ func (c *Client) Start(serverURL string) error {
 // Stops the client.
 // The underlying I/O loop is stopped and all pending requests are cleared.
 func (c *Client) Stop() {
-	// Overwrite handler to intercept disconnected signal
-	cleanupC := make(chan struct{}, 1)
-	c.client.SetDisconnectedHandler(func(err error) {
-		cleanupC <- struct{}{}
-	})
 	c.client.Stop()
 	c.dispatcher.Stop()
-	// Wait for websocket to be cleaned up
-	<-cleanupC
 }
 
 // Sends an OCPP Request to the server.


### PR DESCRIPTION
In the previous version, they introduced a cleanup channel and wait until the websocket client calls the disconnect handler until leaving the `Stop()` function.

In our unit tests however, this failed when running with `goleak.VerifyNone(t)`.

Investigating it further, it turned out that the `DisconnectHandler` is not called when the websocket client is stopped using the `Stop()` function with was done here.

**Documentation:**
```
Sets a callback function for receiving notifications about an unexpected disconnection from the server.
The callback is invoked even if the automatic reconnection mechanism is active.

If the client was stopped using the Stop function, the callback will NOT be invoked.
```

See
https://github.com/grid-x/ocpp-go/blob/c020c2b1039ad5191ac3b23c049b7e50efbff648/ws/websocket.go#L692