### PR TITLE
fix(ws): race condition when closing

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -948,7 +948,9 @@ func (client *Client) IsConnected() bool {
 }
 
 func (client *Client) Write(data []byte) error {
-	if !client.IsConnected() {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	if !client.connected {
 		return fmt.Errorf("client is currently not connected, cannot send data")
 	}
 	log.Debugf("queuing data for server")


### PR DESCRIPTION
Without this, it could happen that
* Write is scheduled, IsConnected is true, but the mutex is unlocked and
  it get rescheduled before the channel send
* cleanup or cleanupConnection is scheduled, which can lock the mutex
  and close outQueue
* Write is scheduled again and tries to send on the closed outQueue