### PR TITLE
fix(bdl): add new BDL supported subprotocol

### DIFF
--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -8,10 +8,14 @@ import (
 )
 
 const (
-	V2Subprotocol      = "ocpp2.0"
-	V201Subprotocol    = "ocpp2.0.1"
-	V201BDLSubprotocol = "ocpp2.0.1.bdl"
+	V2Subprotocol   = "ocpp2.0"
+	V201Subprotocol = "ocpp2.0.1"
 )
+
+// BDL supported subprotocols
+// Note: can change with newer software
+// "ocpp2.0.1bdl" is used with Software 2021.33.15751.NB-rc
+var V201BDLSubprotocols = []string{"ocpp2.0.1.bdl", "ocpp2.0.1bdl"}
 
 type PropertyViolation struct {
 	error

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -400,7 +400,9 @@ func NewCSMS(endpoint *ocppj.Server, server ws.WsServer) CSMS {
 		server = ws.NewServer()
 	}
 	server.AddSupportedSubprotocol(types.V201Subprotocol)
-	server.AddSupportedSubprotocol(types.V201BDLSubprotocol)
+	for _, p := range types.V201BDLSubprotocols {
+		server.AddSupportedSubprotocol(p)
+	}
 	if endpoint == nil {
 		dispatcher := ocppj.NewDefaultServerDispatcher(ocppj.NewFIFOQueueMap(0))
 		endpoint = ocppj.NewServer(server, dispatcher, nil, authorization.Profile, availability.Profile, data.Profile, diagnostics.Profile, display.Profile, firmware.Profile, iso15118.Profile, localauth.Profile, meter.Profile, provisioning.Profile, remotecontrol.Profile, reservation.Profile, security.Profile, smartcharging.Profile, tariffcost.Profile, transactions.Profile)


### PR DESCRIPTION
With the Software Update to 2021.33.15751.NB-rc, they’ve renamed the subprotocol from `ocpp2.0.1.bdl` to `ocpp2.0.1bdl` (without the `.`) (See https://grid-x.atlassian.net/wiki/spaces/INT/pages/2671935491/OCPP+2.0.1+BDL+Kostal#2021.33.15751.NB-rc)
Already tested locally with Kostal Wallbox :+1: 