### PR TITLE
Bug: Prevent blocking Websocket

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -519,7 +519,8 @@ func (cs *centralSystem) handleIncomingRequest(chargePoint ChargePointConnection
 
 func (cs *centralSystem) handleIncomingConfirmation(chargePoint ChargePointConnection, confirmation ocpp.Response, requestId string) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePoint.ID()); ok {
-		callback(confirmation, nil)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(confirmation, nil)
 	} else {
 		err := fmt.Errorf("no handler available for call of type %v from client %s for request %s", confirmation.GetFeatureName(), chargePoint.ID(), requestId)
 		cs.error(err)
@@ -528,7 +529,8 @@ func (cs *centralSystem) handleIncomingConfirmation(chargePoint ChargePointConne
 
 func (cs *centralSystem) handleIncomingError(chargePoint ChargePointConnection, err *ocpp.Error, details interface{}) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePoint.ID()); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for call error %w from client %s", err, chargePoint.ID())
 		cs.error(err)
@@ -537,7 +539,8 @@ func (cs *centralSystem) handleIncomingError(chargePoint ChargePointConnection, 
 
 func (cs *centralSystem) handleCanceledRequest(chargePointID string, request ocpp.Request, err *ocpp.Error) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePointID); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for canceled request %s for client %s: %w",
 			request.GetFeatureName(), chargePointID, err)

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -990,7 +990,8 @@ func (cs *csms) handleIncomingRequest(chargingStation ChargingStationConnection,
 
 func (cs *csms) handleIncomingResponse(chargingStation ChargingStationConnection, response ocpp.Response, requestId string) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargingStation.ID()); ok {
-		callback(response, nil)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(response, nil)
 	} else {
 		err := fmt.Errorf("no handler available for call of type %v from client %s for request %s", response.GetFeatureName(), chargingStation.ID(), requestId)
 		cs.error(err)
@@ -999,7 +1000,8 @@ func (cs *csms) handleIncomingResponse(chargingStation ChargingStationConnection
 
 func (cs *csms) handleIncomingError(chargingStation ChargingStationConnection, err *ocpp.Error, details interface{}) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargingStation.ID()); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		cs.error(fmt.Errorf("no handler available for call error %w from client %s", err, chargingStation.ID()))
 	}
@@ -1007,7 +1009,8 @@ func (cs *csms) handleIncomingError(chargingStation ChargingStationConnection, e
 
 func (cs *csms) handleCanceledRequest(chargePointID string, request ocpp.Request, err *ocpp.Error) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePointID); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for canceled request %s for client %s: %w",
 			request.GetFeatureName(), chargePointID, err)


### PR DESCRIPTION
When the application has longer running code parts in the callback, the callback call will block the underyling websocket.

In one of our customer systems, this caused a big issue.

Since handling the OCPP messages is already done in a go-routine, handling the confirmation messages should also be handled in a go-routine.

Additionally, the same could be good for incoming errors and canceled requests. 