### PR TITLE
Fix value field validation of ChangeConfigurationRequest 

### DIFF
--- a/ocpp1.6/core/change_configuration.go
+++ b/ocpp1.6/core/change_configuration.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Change Configuration (CS -> CP) --------------------
@@ -33,7 +34,7 @@ func isValidConfigurationStatus(fl validator.FieldLevel) bool {
 // The field definition of the ChangeConfiguration request payload sent by the Central System to the Charge Point.
 type ChangeConfigurationRequest struct {
 	Key   string `json:"key" validate:"required,max=50"`
-	Value string `json:"value" validate:"required,max=500"`
+	Value string `json:"value" validate:"omitempty,max=500"`
 }
 
 // This field definition of the ChangeConfiguration confirmation payload, sent by the Charge Point to the Central System in response to a ChangeConfigurationRequest.

--- a/ocpp1.6_test/change_configuration_test.go
+++ b/ocpp1.6_test/change_configuration_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -13,7 +14,7 @@ func (suite *OcppV16TestSuite) TestChangeConfigurationRequestValidation() {
 	t := suite.T()
 	var requestTable = []GenericTestEntry{
 		{core.ChangeConfigurationRequest{Key: "someKey", Value: "someValue"}, true},
-		{core.ChangeConfigurationRequest{Key: "someKey"}, false},
+		{core.ChangeConfigurationRequest{Key: "someKey", Value: ""}, true},
 		{core.ChangeConfigurationRequest{Value: "someValue"}, false},
 		{core.ChangeConfigurationRequest{}, false},
 		{core.ChangeConfigurationRequest{Key: ">50................................................", Value: "someValue"}, false},


### PR DESCRIPTION
At a customer site, we  get important "ChangeConfiguration" messages that we need to forward. This message includes an empty string though and thus, failing in the validation.

To allow empty strings, the field is set to "omitempty".

We had to modify one unit test to allow an empty value.

Sadly, we can't distinugish anymore between an empty value and a value that was not sent at all.
This would require using *string as field parameter.

Since this would also require a huge refactoring in the whole code base - not only for the ChangeConfiguration, we decided to use omitempty here.